### PR TITLE
Fix incorrect filename for version 4.6 and newer

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,10 +11,17 @@ class kibana::install (
   $group               = $::kibana::group,
   $user                = $::kibana::user,
 ) {
-
-  $filename = $::architecture ? {
-    /(i386|x86$)/    => "kibana-${version}-linux-x86",
-    /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+  if '4.6' in $version {
+    $filename = $::architecture ? {
+      /(i386|x86$)/    => "kibana-${version}-linux-x86",
+      /(amd64|x86_64)/ => "kibana-${version}-linux-x86_64",
+    }
+  }
+  else {
+    $filename = $::architecture ? {
+      /(i386|x86$)/    => "kibana-${version}-linux-x86",
+      /(amd64|x86_64)/ => "kibana-${version}-linux-x64",
+  }
   }
 
   $service_provider = $::kibana::params::service_provider


### PR DESCRIPTION
The filename structure for Kibana versions 4.6 and up has changed.   Add support for the new filenames.
